### PR TITLE
fix: update file path to include a leading dot for hidden files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A fast, lightweight, and scalable open-source DBMS for modern apps. Supports JSON-based data storage, simple APIs, and secure data management. Ideal for projects needing efficient and flexible database solutions.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Operation/CRUD Operation/Create.operation.ts
+++ b/source/Operation/CRUD Operation/Create.operation.ts
@@ -44,7 +44,7 @@ export default class Insertion {
       // Check if Directory Locked or not
       const isLocked = await new FolderManager().IsDirectoryLocked(this.path);
       if ("data" in isLocked) {
-        if (isLocked.data == false) {
+        if (isLocked.data === false) {
           // Write the data to the file
           const WriteResponse = await new FileManager().WriteFile(
             filePath,
@@ -52,10 +52,10 @@ export default class Insertion {
           );
           const lockStatus = await new FolderManager().LockDirectory(this.path);
           if ("data" in lockStatus) {
-            if (lockStatus.data == false) {
+            if (lockStatus.data === false) {
               const DeleteStatus = await new FileManager().DeleteFile(filePath);
               if ("data" in DeleteStatus) {
-                if (DeleteStatus.data == false) {
+                if (DeleteStatus.data === false) {
                   return new responseHelper().Error("Failed to lock directory");
                 }
               }
@@ -73,7 +73,7 @@ export default class Insertion {
             this.path,
           );
           if ("data" in unlockStatus) {
-            if (unlockStatus.data == false) {
+            if (unlockStatus.data === false) {
               return new responseHelper().Error("Failed to unlock directory");
             } else {
               // Write the data to the file
@@ -85,7 +85,7 @@ export default class Insertion {
                 this.path,
               );
               if ("data" in lockStatus) {
-                if (lockStatus.data == false) {
+                if (lockStatus.data === false) {
                   return new responseHelper().Error("Failed to lock directory");
                 } else {
                   if (WriteResponse.status) {

--- a/source/Operation/CRUD Operation/Create.operation.ts
+++ b/source/Operation/CRUD Operation/Create.operation.ts
@@ -39,7 +39,7 @@ export default class Insertion {
   ): Promise<SuccessInterface | ErrorInterface> {
     try {
       const documentId = await this.generateUniqueDocumentId();
-      const filePath = `${this.path}/${documentId}${General.DBMS_File_EXT}`;
+      const filePath = `${this.path}/.${documentId}${General.DBMS_File_EXT}`;
 
       // Check if Directory Locked or not
       const isLocked = await new FolderManager().IsDirectoryLocked(this.path);


### PR DESCRIPTION
This pull request includes a version update for the `axiodb` package and a minor change to the file path generation in the `Insertion` class.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.3.4` to `1.3.5`.

File path modification:

* [`source/Operation/CRUD Operation/Create.operation.ts`](diffhunk://#diff-51223f9e541cadafc0cc4f6cd901cb762f4a02cafb14248ea9a146f1ee11117dL42-R42): Changed the file path generation in the `Insertion` class to prefix the document ID with a dot.