### PR TITLE
fix: update version to 1.5.6 and change funding field format in packa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A fast, lightweight, and scalable open-source DBMS for modern apps. Supports JSON-based data storage, simple APIs, and secure data management. Ideal for projects needing efficient and flexible database solutions.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",
@@ -23,7 +23,8 @@
   ],
   "author": "Ankan Saha",
   "license": "MIT",
-  "sponsor": {
+  "funding": {
+    "type": "git",
     "url": "https://github.com/sponsors/AnkanSaha"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request includes a version update and a change in the funding information in the `package.json` file.

* Updated the version of the `axiodb` package from `1.5.5` to `1.5.6`.
* Changed the `sponsor` field to `funding` and specified the funding type as `git`.…ge.json