### PR TITLE
chore: update version to 1.7.9 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "1.7.7",
+  "version": "1.7.9",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a version update for the `axiodb` package. The version has been incremented from `1.7.7` to `1.7.9`.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `1.7.7` to `1.7.9`.