### PR TITLE
chore: update version to 2.7.11 in package.json and export InMemoryCa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "1.7.10",
+  "version": "2.7.11",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Caching/cache.operation.ts
+++ b/source/Caching/cache.operation.ts
@@ -6,7 +6,7 @@
  * @version 1.0.1
  * @since 24 December 2024
  **/
-class InMemoryCache {
+export class InMemoryCache {
   // Properties
   private readonly ttl: number;
   private cacheObject: { [key: string]: { value: any; registeredAt: Date } };

--- a/source/config/DB.ts
+++ b/source/config/DB.ts
@@ -22,9 +22,8 @@ const InstanceTypes = {
   Converter,
   CryptoHelper,
   ResponseHelper,
-  InMemoryCache
-
-}
+  InMemoryCache,
+};
 // Export Specific Modules
 export { SchemaTypes, schemaValidate, AxioDB, InstanceTypes };
 
@@ -33,5 +32,5 @@ export default {
   SchemaTypes,
   schemaValidate,
   AxioDB,
-  InstanceTypes
+  InstanceTypes,
 };

--- a/source/config/DB.ts
+++ b/source/config/DB.ts
@@ -1,14 +1,37 @@
 // Import All Required Sub Modules
+import { InMemoryCache } from "../Caching/cache.operation";
+import Converter from "../Helper/Converter.helper";
+import { CryptoHelper } from "../Helper/Crypto.helper";
+import ResponseHelper from "../Helper/response.helper";
 import { SchemaTypes } from "../Models/DataTypes.models";
 import schemaValidate from "../Models/validator.models";
+import Aggregation from "../Operation/Aggregation/Aggregation.Operation";
+import Collection from "../Operation/Collection/collection.operation";
+import Database from "../Operation/Database/database.operation";
 import { AxioDB } from "../Operation/Indexation.operation";
+import FileManager from "../Storage/FileManager";
+import FolderManager from "../Storage/FolderManager";
 
+// Export All Required Sub Modules Instance Types to support TypeScript
+const InstanceTypes = {
+  Collection,
+  Database,
+  Aggregation,
+  FileManager,
+  FolderManager,
+  Converter,
+  CryptoHelper,
+  ResponseHelper,
+  InMemoryCache
+
+}
 // Export Specific Modules
-export { SchemaTypes, schemaValidate, AxioDB };
+export { SchemaTypes, schemaValidate, AxioDB, InstanceTypes };
 
 // Export With All Sub Modules
 export default {
   SchemaTypes,
   schemaValidate,
   AxioDB,
+  InstanceTypes
 };


### PR DESCRIPTION
This pull request includes several changes to the `axiodb` package to update its version, export the `InMemoryCache` class, and import and export multiple helper and operation modules in the `DB.ts` configuration file.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.7.10` to `2.7.11`.

Class export modification:

* [`source/Caching/cache.operation.ts`](diffhunk://#diff-5da2f3345a3492e6eab089f28e81666a57e6d1d88463113da6871eaf1888f873L9-R9): Changed the `InMemoryCache` class to be exported.

Module imports and exports:

* [`source/config/DB.ts`](diffhunk://#diff-f00be82faed3cfed174e57fdd7b3bbfa8c9f5ad9717605b95cb851072a300aa1R2-R36): Added imports for `InMemoryCache`, `Converter`, `CryptoHelper`, `ResponseHelper`, `Aggregation`, `Collection`, `Database`, `FileManager`, and `FolderManager`.
* [`source/config/DB.ts`](diffhunk://#diff-f00be82faed3cfed174e57fdd7b3bbfa8c9f5ad9717605b95cb851072a300aa1R2-R36): Added `InstanceTypes` object to export instances of the newly imported modules.
* [`source/config/DB.ts`](diffhunk://#diff-f00be82faed3cfed174e57fdd7b3bbfa8c9f5ad9717605b95cb851072a300aa1R2-R36): Updated the export statement to include `InstanceTypes` along with `SchemaTypes`, `schemaValidate`, and `AxioDB`.…che in DB module