### PR TITLE
fix: remove unnecessary init property from First Time Setup task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,4 +26,3 @@ vscode:
 tasks:
   - name: First Time Setup
   - command: bash ./.devcontainer/postCreateCommand.sh
-    init: true


### PR DESCRIPTION
This pull request makes a small change to the `.gitpod.yml` file by removing the `init: true` property from the "First Time Setup" task.