### PR TITLE
fix: update package version from 2.10.14 to 2.10.15 in package.json a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axiodb",
-  "version": "1.7.2",
+  "version": "2.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axiodb",
-      "version": "1.7.2",
+      "version": "2.10.14",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a version bump for the `axiodb` package in the `package.json` file.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.10.14` to `2.10.15` to reflect a new release.…nd package-lock.json