### PR TITLE
fix: update package version from 2.10.15 to 2.10.16 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.10.15",
+  "version": "2.10.16",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a version bump for the `axiodb` package in the `package.json` file. The version has been updated from `2.10.15` to `2.10.16` to reflect changes or improvements in the package.