### PR TITLE
fix: update version to 2.10.19-stable in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.10.18-stable",
+  "version": "2.10.19-stable",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a minor version update for the `axiodb` package in the `package.json` file. The version has been incremented from `2.10.18-stable` to `2.10.19-stable`.