### PR TITLE
fix: update npm install commands and increment version to 2.10.20-sta…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm ci
+          command: npm install --force
       - run:
           name: Run Tests
           command: echo "Tests Passed"
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm ci
+          command: npm install --force
       - run:
           name: Build Package
           command: npm run build
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm install
+          command: npm install --force
       - run:
           name: Build Package
           command: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axiodb",
-  "version": "2.10.14",
+  "version": "2.10.20-stable",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axiodb",
-      "version": "2.10.14",
+      "version": "2.10.20-stable",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.11.1",


### PR DESCRIPTION
This pull request updates the dependency installation commands in the CircleCI configuration file to ensure compatibility with potential package conflicts. The changes replace `npm ci` and `npm install` with `npm install --force` across multiple jobs.

Dependency installation updates in `.circleci/config.yml`:

* Replaced `npm ci` with `npm install --force` in the "Install Dependencies" step of the test job.
* Replaced `npm ci` with `npm install --force` in the "Install Dependencies" step of the build job.
* Replaced `npm install` with `npm install --force` in the "Install Dependencies" step of another build job.…ble in package-lock.json