### PR TITLE
refactor: remove redundant 'prepare' script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "test": "echo 'Test script Succesful'",
     "build": "tsc",
-    "prepare": "npm run build",
     "lint": "eslint ."
   },
   "keywords": [


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change removes the `prepare` script, which previously triggered the `build` command.