### PR TITLE
fix: update install commands to use 'npm ci' for consistency and add …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm install --force
+          command: npm ci
       - run:
           name: Run Tests
           command: echo "Tests Passed"
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm install --force
+          command: npm ci
       - run:
           name: Build Package
           command: npm run build
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm install --force
+          command: npm install
       - run:
           name: Build Package
           command: npm run build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "echo 'Test script Succesful'",
     "build": "tsc",
+    "prepare": "npm run build",
     "lint": "eslint ."
   },
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "rootDir": "./source" // Specify the root directory for your source code
   },
   "include": ["source/**/*.ts", "source/**/*.tsx"], // Include TypeScript and TSX files
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "source/Docker/**"]
 }


### PR DESCRIPTION
This pull request includes updates to the CI/CD pipeline configuration and the `package.json` file to streamline dependency installation and improve build processes. The changes primarily focus on replacing `npm install --force` with more appropriate commands and adding a new `prepare` script.

### CI/CD pipeline updates:
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L12-R12): Updated dependency installation commands in multiple jobs to replace `npm install --force` with `npm ci` for cleaner and faster installs where lockfiles exist, and with `npm install` where lockfiles are not guaranteed. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L12-R12) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L25-R25) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L44-R44)

### Build process improvement:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R10): Added a new `prepare` script that automatically runs the `build` script, ensuring the package is properly built during preparation steps.…Docker exclusion in tsconfig