### PR TITLE
fix: add stable tag to npm publish commands for consistency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
       - run:
           name: Publish to NPM Registry
-          command: npm publish --access public
+          command: npm publish --access public --tag stable
 
   Publish_To_Github:
     docker:
@@ -56,7 +56,7 @@ jobs:
             sed -i "2s/\"axiodb\"/\"@${GITHUB_USER_NAME}\/axiodb\"/" package.json
       - run:
           name: Publish to Github Package Registry
-          command: npm publish --registry=https://npm.pkg.github.com --scope=@${GITHUB_USER_NAME} --access public
+          command: npm publish --registry=https://npm.pkg.github.com --scope=@${GITHUB_USER_NAME} --access public --tag stable
 
 workflows:
   version: 2


### PR DESCRIPTION
This pull request updates the `.circleci/config.yml` file to ensure that packages are published with the `stable` tag in both the NPM Registry and the GitHub Package Registry.

Publishing updates:

* Updated the NPM publishing command to include the `--tag stable` option, ensuring packages are tagged as stable during publication. (`[.circleci/config.ymlL34-R34](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L34-R34)`)
* Updated the GitHub Package Registry publishing command to include the `--tag stable` option for consistent tagging across registries. (`[.circleci/config.ymlL59-R59](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L59-R59)`)