### PR TITLE
fix: update version to 2.10.22-stable in package.json and adjust Dock…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,6 @@ jobs:
       - setup_remote_docker # Use default Docker version (currently Docker 24.0.6)
 
       - run:
-          name: Change Docker working directory
-          command: |
-            cd ./source/Docker && ls
-      - run:
           name: Login to Docker Hub
           command: |
             echo "$DOCKERHUB_API_KEY" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
@@ -82,7 +78,7 @@ jobs:
       - run:
           name: Build Docker image with version and latest tags
           command: |
-            docker build -t $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG .
+            cd ./source/Docker && ls && docker build -t $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG .
             docker tag $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG \
                        $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:latest
 
@@ -109,7 +105,7 @@ jobs:
       - run:
           name: Build Docker image with version and latest tags
           command: |
-            docker build -t $GITHUB_REGISTRY/$GITHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG .
+            cd ./source/Docker && ls && docker build -t $GITHUB_REGISTRY/$GITHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG .
             docker tag $GITHUB_REGISTRY/$GITHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG \
             $GITHUB_REGISTRY/$GITHUB_USERNAME/$DOCKER_IMAGE:latest
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.10.21-stable",
+  "version": "2.10.22-stable",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes updates to the `.circleci/config.yml` file to streamline Docker commands and a version bump in `package.json`. The most important changes involve consolidating Docker directory navigation and modifying the Docker build process.

### Updates to Docker commands in `.circleci/config.yml`:

* Removed a separate step for changing the Docker working directory and integrated the directory navigation directly into the Docker build commands. This simplifies the pipeline by reducing redundant steps. (`jobs` section: [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L73-L76) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L85-R81) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L112-R108)

### Version bump in `package.json`:

* Updated the version of the `axiodb` package from `2.10.21-stable` to `2.10.22-stable` to reflect the latest changes. (`package.json`: [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))…er build commands