### PR TITLE
fix: update package version to 2.10.23 and adjust NPM publish commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
       - run:
           name: Publish to NPM Registry
-          command: npm publish --access public --tag stable
+          command: npm publish --access public
 
-# Jobs for AxioDB package publishing to GitHub Package Registry
+  # Jobs for AxioDB package publishing to GitHub Package Registry
   Publish_To_Github:
     docker:
       - image: node:latest
@@ -58,10 +58,9 @@ jobs:
             sed -i "2s/\"axiodb\"/\"@${GITHUB_USER_NAME}\/axiodb\"/" package.json
       - run:
           name: Publish to Github Package Registry
-          command: npm publish --registry=https://npm.pkg.github.com --scope=@${GITHUB_USER_NAME} --access public --tag stable
+          command: npm publish --registry=https://npm.pkg.github.com --scope=@${GITHUB_USER_NAME} --access public
 
-
-# Jobs for Docker image build and push to Docker Hub
+  # Jobs for Docker image build and push to Docker Hub
   push_To_DockerHub:
     docker:
       - image: cimg/base:stable # CircleCI's base image with Docker support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.10.22-stable",
+  "version": "2.10.23",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request focuses on simplifying the publishing process for the `axiodb` package and updating its version. The most notable changes include removing the `stable` tag from the `npm publish` commands and incrementing the package version in `package.json`.

### Publishing process updates:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L35-R35): Removed the `--tag stable` flag from the `npm publish` command for publishing to both the NPM Registry and GitHub Package Registry, simplifying the publishing process. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L35-R35) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L61-R61)

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.10.22-stable` to `2.10.23`, reflecting the removal of the `stable` tag and indicating a new release.