### PR TITLE
fix: update version to 2.10.27 in package.json and adjust .npmignore …

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -27,4 +27,4 @@ test
 ./source/**/*
 
 # Ignore the following directories and files for the GUI
-./Document
+Document/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern applications. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes two small changes: an update to the `.npmignore` file and a version bump in `package.json`.

* [`.npmignore`](diffhunk://#diff-34958b02363eec9a904716f0b4a8782b021c6b33b2e8599019e36c88e045240bL30-R30): Updated the `test` section to change the way the `Document` directory is ignored by replacing `./Document` with `Document/`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the package version from `2.10.26` to `2.10.27`.…for Document directory