### PR TITLE
fix: refine error message in validateToken middleware for clarity

### DIFF
--- a/source/Docker/Middlewares/validateToken.middleware.ts
+++ b/source/Docker/Middlewares/validateToken.middleware.ts
@@ -1,4 +1,4 @@
-import { FastifyReply, FastifyRequest } from "fastify";
+import { FastifyReply } from "fastify";
 import { StatusCodes } from "outers";
 import { RequestBody } from "../config/Interfaces/RequestInterface";
 import { ClassBased } from "outers";
@@ -16,7 +16,7 @@ export default async function validateToken(
     return reply.status(StatusCodes.UNAUTHORIZED).send({
       statusCode: StatusCodes.UNAUTHORIZED,
       success: false,
-      error: "Unauthorized",
+      error: "Unauthorized user",
       message:
         "No service token provided, please provide servicetoken in the header",
     });


### PR DESCRIPTION
This pull request makes minor updates to the `validateToken.middleware.ts` file, including refining error messaging and removing an unused import.

Code cleanup and messaging improvements:

* [`source/Docker/Middlewares/validateToken.middleware.ts`](diffhunk://#diff-0b5e8efca56d2a3ba61105241ac3212d39d97e644cc7836f38c4a63516a6db5bL1-R1): Removed the unused `FastifyRequest` import to clean up the code.
* [`source/Docker/Middlewares/validateToken.middleware.ts`](diffhunk://#diff-0b5e8efca56d2a3ba61105241ac3212d39d97e644cc7836f38c4a63516a6db5bL19-R19): Updated the error message from "Unauthorized" to "Unauthorized user" for better clarity in responses.