### PR TITLE
refactor: remove Test job and its dependencies from the CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,6 @@ version: 2.1
 
 jobs:
   # Jobs for AxioDB package testing and publishing to NPM Package Registry
-  Test:
-    docker:
-      - image: node:latest
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - run:
-          name: Install Dependencies
-          command: npm ci
-      - run:
-          name: Run Tests
-          command: echo "Tests Passed"
-
   Publish_To_NPM:
     docker:
       - image: node:latest
@@ -247,37 +234,23 @@ workflows:
   version: 2
   Pipeline:
     jobs:
-      - Test:
-          filters:
-            branches:
-              only: main
       - Publish_To_NPM:
-          requires:
-            - Test
           filters:
             branches:
               only: main
       - Publish_To_Github:
-          requires:
-            - Test
           filters:
             branches:
               only: main
       - push_To_DockerHub:
-          requires:
-            - Test
           filters:
             branches:
               only: main
       - push_To_Github:
-          requires:
-            - Test
           filters:
             branches:
               only: main
       - Send_To_Server:
-          requires:
-            - Test
           filters:
             branches:
               only: main


### PR DESCRIPTION
This pull request removes the `Test` job from the CircleCI configuration file, along with all associated dependencies in the workflow. The changes simplify the CI/CD pipeline by eliminating the test step as a prerequisite for other jobs.

### Removal of the `Test` job:
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L5-L17): Deleted the `Test` job, which included steps for installing dependencies and running tests.

### Workflow simplifications:
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L250-L280): Removed the `Test` job as a prerequisite for other jobs (`Publish_To_NPM`, `Publish_To_Github`, `push_To_DockerHub`, `push_To_Github`, and `Send_To_Server`) in the `Pipeline` workflow.