### PR TITLE
fix: re-enable eslint rule for explicit 'any' type in SchemaGenerator…

### DIFF
--- a/source/Docker/util/SchemaGenerator.util.ts
+++ b/source/Docker/util/SchemaGenerator.util.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { SchemaTypes } from "axiodb";
 
 /**


### PR DESCRIPTION
This pull request includes a minor change to the `SchemaGenerator.util.ts` file. The change disables the `@typescript-eslint/no-explicit-any` rule to allow the use of the `any` type in this file.… utility