### PR TITLE
fix: correct Docker build directory path in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: Build Docker image with version and latest tags
           command: |
-            cd ./source/Docker && ls && docker build -t $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG .
+            cd ./Docker && ls && docker build -t $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG .
             docker tag $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:$DOCKER_VERSION_TAG \
                        $DOCKER_REGISTRY/$DOCKERHUB_USERNAME/$DOCKER_IMAGE:latest
 


### PR DESCRIPTION
This pull request includes a small change to the `.circleci/config.yml` file. The change updates the directory path for building the Docker image from `./source/Docker` to `./Docker` to ensure the correct path is used.