### PR TITLE
fix: reorder AxioControl directory move in Dockerfile for clarity

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,14 +13,14 @@ RUN npm install
 # Copy the rest of the application source code from the current directory to the working directory in the container
 COPY . .
 
-# Move the AxioControl directory to the correct location
-RUN mv ./AxioControl ./build/
-
 # Install TypeScript and ts-node globally
 RUN npm install -g typescript ts-node
 
 # Compile TypeScript to JavaScript
 RUN npm run build && npm run copy-protos
+
+# Move the AxioControl directory to the correct location
+RUN mv ./AxioControl ./build/
 
 # Expose the port the app runs on
 EXPOSE 27018


### PR DESCRIPTION
This pull request includes a minor change to the `Docker/Dockerfile`. The order of commands was adjusted to move the `AxioControl` directory after the TypeScript installation and build steps. This ensures the directory is relocated after the TypeScript compilation process.

* [`Docker/Dockerfile`](diffhunk://#diff-e37a35db487b2f0d3252aad30cbf618f28dc8e62e0707a0bf4791364178a15d9L16-R24): Reordered the `RUN mv ./AxioControl ./build/` command to occur after the TypeScript installation and build steps.