### PR TITLE
feat: add key and run scripts for database instance creation and mana…

### DIFF
--- a/Test/key.js
+++ b/Test/key.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-undef */
+const Data_Dir = "TestDB";
+const Count_To_Loop_DB = 10;
+
+module.exports = {
+  Data_Dir: Data_Dir,
+  Count_To_Loop_DB: Count_To_Loop_DB
+};

--- a/Test/key.js
+++ b/Test/key.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 const Data_Dir = "TestDB";
-const Count_To_Loop_DB = 10;
+const Count_To_Loop_DB = 100;
 
 module.exports = {
   Data_Dir: Data_Dir,

--- a/Test/run.js
+++ b/Test/run.js
@@ -1,4 +1,4 @@
-const { AxioDB } = require("../lib/config/DB.js");
+const { AxioDB, SchemaTypes } = require("../lib/config/DB.js");
 const key = require("./key.js")
 
 
@@ -6,6 +6,11 @@ const main = async () => {
   let DbInstances = {};
   let DBs = {};
   let Collections = {};
+
+  const schema = {
+    name: SchemaTypes.string().required(),
+    age: SchemaTypes.number().required()
+  }
 
   // Create multiple DB instances
   for (let i = 0; i < key.Count_To_Loop_DB; i++) {
@@ -19,8 +24,14 @@ const main = async () => {
       
       // Create multiple collections within each database
       for (let k = 0; k < key.Count_To_Loop_DB; k++) {
-        const collection = await database.createCollection(`TestCollection${i}_${j}_${k}`);
-        Collections[`TestCollection${i}_${j}_${k}`] = collection;
+        let even = k % 2 === 0;
+        if (even == true) {
+          const collection = await database.createCollection(`TestCollection${i}_${j}_${k}`, schema, even, "MeyKey");
+          Collections[`TestCollection${i}_${j}_${k}`] = collection;
+        }else {
+          const collection = await database.createCollection(`TestCollection${i}_${j}_${k}`, schema, even);
+          Collections[`TestCollection${i}_${j}_${k}`] = collection;
+        }
       }
     }
   }

--- a/Test/run.js
+++ b/Test/run.js
@@ -1,0 +1,32 @@
+const { AxioDB } = require("../lib/config/DB.js");
+const key = require("./key.js")
+
+
+const main = async () => {
+  let DbInstances = {};
+  let DBs = {};
+  let Collections = {};
+
+  // Create multiple DB instances
+  for (let i = 0; i < key.Count_To_Loop_DB; i++) {
+    const dbInstance = new AxioDB(`MainDB${i}`, `./${key.Data_Dir}`);
+    DbInstances[`MainDBInstance${i}`] = dbInstance;
+    
+    // Create multiple databases within each instance
+    for (let j = 0; j < key.Count_To_Loop_DB; j++) {
+      const database = await dbInstance.createDB(`TestDB${i}_${j}`);
+      DBs[`TestDB${i}_${j}`] = database;
+      
+      // Create multiple collections within each database
+      for (let k = 0; k < key.Count_To_Loop_DB; k++) {
+        const collection = await database.createCollection(`TestCollection${i}_${j}_${k}`);
+        Collections[`TestCollection${i}_${j}_${k}`] = collection;
+      }
+    }
+  }
+}
+
+
+main().then(() => {
+  process.exit(0);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axiodb",
-  "version": "2.11.30",
+  "version": "2.11.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axiodb",
-      "version": "2.11.30",
+      "version": "2.11.31",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",
   "scripts": {
-    "test": "echo 'Test script Succesful'",
+    "test": "node ./Test/run.js",
     "build": "tsc",
     "lint": "eslint ."
   },


### PR DESCRIPTION
This pull request introduces functionality for testing database operations by creating multiple instances, databases, and collections dynamically. It also updates the test script in `package.json` to execute the new test logic. The most important changes are the addition of a configuration file for test parameters, the implementation of the test logic, and the update to the test script.

### Test functionality additions:

* [`Test/key.js`](diffhunk://#diff-38d94b551e0058214be50b57bc628f8d45b62706c75d94cd32592ae8cef57d25R1-R8): Added a configuration file to define constants such as `Data_Dir` and `Count_To_Loop_DB`, which are used to control the test setup.

* [`Test/run.js`](diffhunk://#diff-a5bbbabb1e09f68091f332f0a8561f33a46caef2a02bdd42668f464d5eeb403fR1-R32): Implemented the main test logic to dynamically create multiple database instances, databases, and collections using the `AxioDB` class. The script initializes objects to store references to these entities and exits the process after execution.

### Test script update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8): Updated the `test` script to run the new test logic in `Test/run.js` instead of a placeholder echo command.…gement