### PR TITLE
fix: exclude GUI directory from TypeScript compilation

### DIFF
--- a/Docker/tsconfig.json
+++ b/Docker/tsconfig.json
@@ -26,6 +26,7 @@
     "./**/*.proto"
   ], // Include TypeScript, TSX, and Proto files
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "GUI",
   ]
 }


### PR DESCRIPTION
This pull request updates the `Docker/tsconfig.json` file to exclude the `GUI` directory from the TypeScript configuration. This change ensures that files in the `GUI` directory are not processed during TypeScript compilation.