### PR TITLE
fix: change ENTRYPOINT from bash to sh in Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -36,4 +36,4 @@ EXPOSE 27023
 EXPOSE 27024
 
 # Command to run the application
-ENTRYPOINT ["bash", "-c", "npm run run-gui & npm run start"]
+ENTRYPOINT ["sh", "-c", "npm run run-gui & npm run start"]


### PR DESCRIPTION
This pull request makes a small change to the `Docker/Dockerfile` to update the shell used in the `ENTRYPOINT` command.

* [`Docker/Dockerfile`](diffhunk://#diff-e37a35db487b2f0d3252aad30cbf618f28dc8e62e0707a0bf4791364178a15d9L39-R39): Changed the shell from `bash` to `sh` in the `ENTRYPOINT` command to improve compatibility or align with the base image.