### PR TITLE
fix: remove CircleCI badge from Introduction component

### DIFF
--- a/Document/src/components/content/Introduction.tsx
+++ b/Document/src/components/content/Introduction.tsx
@@ -19,11 +19,6 @@ const Introduction: React.FC = () => {
           className="h-6"
         />
         <img
-          src="https://dl.circleci.com/status-badge/img/gh/AnkanSaha/AxioDB/tree/main.svg?style=svg"
-          alt="CircleCI"
-          className="h-6"
-        />
-        <img
           src="https://socket.dev/api/badge/npm/package/axiodb"
           alt="Socket Security"
           className="h-6"


### PR DESCRIPTION
This pull request removes an outdated CircleCI status badge from the `Introduction` component in the `Document/src/components/content/Introduction.tsx` file.

* **UI Cleanup**:
  * Removed the `<img>` tag displaying the CircleCI status badge, as it is no longer relevant.