### PR TITLE
fix: update version number to 2.13.45 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.13.44",
+  "version": "2.13.45",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a version bump for the `axiodb` package in the `package.json` file. The version has been updated from `2.13.44` to `2.13.45` to reflect the latest changes.