### PR TITLE
fix: update workflow to skip tests and publishing unless package.json…

### DIFF
--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -11,6 +11,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Skip unless only package.json changed
+        run: |
+          FILES=$(git diff HEAD~1 HEAD --name-only)
+          if echo "$FILES" | grep -qv '^package.json'; then
+            echo "Non-package.json changes detected; skipping test."
+            exit 0
+          fi
+          if ! echo "$FILES" | grep -q '^package.json'; then
+            echo "package.json not changed; skipping test."
+            exit 0
+          fi
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -24,10 +35,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Check if package.json changed
+      - name: Skip unless only package.json changed
         run: |
-          CHANGED=$(git diff HEAD~1 HEAD --name-only | grep "^package.json" || true)
-          if [ -z "$CHANGED" ]; then echo "No changes in package.json, skipping Publish_To_NPM."; exit 0; fi
+          FILES=$(git diff HEAD~1 HEAD --name-only)
+          if echo "$FILES" | grep -qv '^package.json'; then
+            echo "Non-package.json changes detected; skipping Publish_To_NPM."
+            exit 0
+          fi
+          if ! echo "$FILES" | grep -q '^package.json'; then
+            echo "package.json not changed; skipping Publish_To_NPM."
+            exit 0
+          fi
       - name: Install dependencies
         run: npm ci
       - name: Build package
@@ -43,10 +61,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Check if package.json changed
+      - name: Skip unless only package.json changed
         run: |
-          CHANGED=$(git diff HEAD~1 HEAD --name-only | grep "^package.json" || true)
-          if [ -z "$CHANGED" ]; then echo "No changes in package.json, skipping Publish_To_Github."; exit 0; fi
+          FILES=$(git diff HEAD~1 HEAD --name-only)
+          if echo "$FILES" | grep -qv '^package.json'; then
+            echo "Non-package.json changes detected; skipping Publish_To_Github."
+            exit 0
+          fi
+          if ! echo "$FILES" | grep -q '^package.json'; then
+            echo "package.json not changed; skipping Publish_To_Github."
+            exit 0
+          fi
       - name: Install dependencies
         run: npm install
       - name: Build package
@@ -101,3 +126,16 @@ jobs:
       - name: Remove old Nginx static files
         if: steps.check_changes.outputs.changed != ''
         run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.VM_IP }} "sudo rm -rf /etc/nginx/sites-enabled/default"
+      - name: Upload new Nginx config
+        if: steps.check_changes.outputs.changed != ''
+        run: |
+          scp -o StrictHostKeyChecking=no Document/${{ secrets.PROJECT_NAME }}.conf ${{ secrets.SSH_USER }}@${{ secrets.VM_IP }}:/etc/nginx/sites-available/
+      - name: Enable new Nginx site
+        if: steps.check_changes.outputs.changed != ''
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.VM_IP }} "sudo ln -s /etc/nginx/sites-available/${{ secrets.PROJECT_NAME }}.conf /etc/nginx/sites-enabled/"
+      - name: Restart Nginx
+        if: steps.check_changes.outputs.changed != ''
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.VM_IP }} "sudo systemctl restart nginx"


### PR DESCRIPTION
This pull request updates the `.github/workflows/Push.yml` file to improve the handling of workflow steps by refining conditions for triggering specific actions and adding new steps for Nginx configuration management. The most important changes are grouped into workflow refinements and Nginx configuration updates.

### Workflow refinements:
* Updated steps to skip actions unless only `package.json` has changed, replacing the previous logic with a more robust check for non-`package.json` changes. This ensures unnecessary steps are not executed when irrelevant files are modified. (`[[1]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dR14-R24)`, `[[2]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL27-R48)`, `[[3]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL46-R74)`)

### Nginx configuration updates:
* Added steps to manage Nginx configuration dynamically, including removing old static files, uploading a new configuration, enabling the new site, and restarting Nginx. These steps are conditional on detected changes. (`[.github/workflows/Push.ymlR129-R141](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dR129-R141)`)… is changed