### PR TITLE
refactor: remove unused AxioDB initialization from a.js

### DIFF
--- a/a.js
+++ b/a.js
@@ -1,3 +1,0 @@
-const { AxioDB } = require("./lib/config/DB.js");
-
-const newDB = new AxioDB();


### PR DESCRIPTION
This pull request removes unused code related to database initialization in `a.js`. Specifically, it eliminates the import of `AxioDB` and its instantiation.

Code cleanup:

* [`a.js`](diffhunk://#diff-dc5985b2a377c4ea735c99979da277be3bd24be88cf411c11b52b5c3f9570536L1-L3): Removed the import of `AxioDB` from `./lib/config/DB.js` and the instantiation of `newDB`, as they were not being used.