### PR TITLE
refactor: remove Docker dependency installation from postCreateComman…

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -10,9 +10,6 @@ sudo apt-get install -y nodejs # Install Node.js and npm
 # Install Dependencies for all the section of this project
 npm install --force && npm run build # Install & build dependencies for AxioDB main Codebase
 
-# Install Dependencies for the AxioDB Docker
-cd ./Docker && npm i --force && cd .. # Install & build dependencies for AxioDB Docker
-
 # Install Dependencies for the AxioDB Documentation
 cd ./Document && npm i --force && cd .. # Install & build dependencies for AxioDB Documentation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.13.49",
+  "version": "2.13.50",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request simplifies the post-create command script in the `.devcontainer` directory by removing redundant installation steps for the Docker section of the AxioDB project.

Key change:

* [`.devcontainer/postCreateCommand.sh`](diffhunk://#diff-047cadacfac3bb0c9fde7443892eb3f394d677a281985d6416b80abf54c2800eL13-L15): Removed the installation and build commands for the AxioDB Docker section to streamline the script and avoid redundancy.…d.sh