### PR TITLE
Maintainer/ankan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axiodb",
-  "version": "2.13.47",
+  "version": "2.13.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axiodb",
-      "version": "2.13.47",
+      "version": "2.13.50",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.13.50",
+  "version": "2.13.51",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Operation/Indexation.operation.ts
+++ b/source/Operation/Indexation.operation.ts
@@ -32,8 +32,13 @@ export class AxioDB {
   private folderManager: FolderManager;
   private Converter: Converter;
   private ResponseHelper: ResponseHelper;
+  private static _instance: AxioDB;
 
   constructor(RootName?: string, CustomPath?: string) {
+    if (AxioDB._instance) {
+      throw new Error("Only one instance of AxioDB is allowed.");
+    }
+    AxioDB._instance = this;
     this.RootName = RootName || General.DBMS_Name; // Set the root name
     this.currentPATH = path.resolve(CustomPath || "."); // Set the current path
     this.fileManager = new FileManager(); // Initialize the FileManager class

--- a/source/server/config/PortFreeChecker.ts
+++ b/source/server/config/PortFreeChecker.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import net from 'net';
+import { exec } from 'child_process';
+import { ServerKeys } from './keys';
+
+export function isPortInUse(port: number, host = ServerKeys.LOCALHOST) {
+  return new Promise((resolve) => {
+    const server = net.createServer()
+      .once('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          resolve(true); // Port is in use
+          throw new Error(`Port ${port} is already in use. Please Free the port to get the GUI.`);
+        } else {
+          resolve(false); // Other error
+        }
+      })
+      .once('listening', () => {
+        server.close();
+        resolve(false); // Port is free
+      })
+      .listen(port, String(host));
+  });
+}
+
+
+export async function checkDockerPortMapping(port:number) {
+  exec(`docker ps --format "{{.ID}} {{.Ports}}"`, (error, stdout, _stderr) => {
+    if (error) {
+      console.error(`Error executing docker: ${error.message}`);
+      return;
+    }
+
+    const containers = stdout.trim().split('\n');
+    const matching = containers.filter(line => line.includes(`:${port}->`));
+
+    if (matching.length > 0) {
+      console.log(`Docker container(s) found using port ${port}:`);
+      matching.forEach(c => console.log(c));
+      throw new Error(`Port ${port} is already mapped to a Docker container. Please stop the container or Please Free the port to get the GUI.`);
+    }
+  });
+}
+
+export default async function checkPortAndDocker(port: number) {
+  await isPortInUse(port);
+  await checkDockerPortMapping(port);
+}

--- a/source/server/config/PortFreeChecker.ts
+++ b/source/server/config/PortFreeChecker.ts
@@ -1,20 +1,23 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import net from 'net';
-import { exec } from 'child_process';
-import { ServerKeys } from './keys';
+import net from "net";
+import { exec } from "child_process";
+import { ServerKeys } from "./keys";
 
 export function isPortInUse(port: number, host = ServerKeys.LOCALHOST) {
   return new Promise((resolve) => {
-    const server = net.createServer()
-      .once('error', (err: NodeJS.ErrnoException) => {
-        if (err.code === 'EADDRINUSE') {
+    const server = net
+      .createServer()
+      .once("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE") {
           resolve(true); // Port is in use
-          throw new Error(`Port ${port} is already in use. Please Free the port to get the GUI.`);
+          throw new Error(
+            `Port ${port} is already in use. Please Free the port to get the GUI.`,
+          );
         } else {
           resolve(false); // Other error
         }
       })
-      .once('listening', () => {
+      .once("listening", () => {
         server.close();
         resolve(false); // Port is free
       })
@@ -22,21 +25,22 @@ export function isPortInUse(port: number, host = ServerKeys.LOCALHOST) {
   });
 }
 
-
-export async function checkDockerPortMapping(port:number) {
+export async function checkDockerPortMapping(port: number) {
   exec(`docker ps --format "{{.ID}} {{.Ports}}"`, (error, stdout, _stderr) => {
     if (error) {
       console.error(`Error executing docker: ${error.message}`);
       return;
     }
 
-    const containers = stdout.trim().split('\n');
-    const matching = containers.filter(line => line.includes(`:${port}->`));
+    const containers = stdout.trim().split("\n");
+    const matching = containers.filter((line) => line.includes(`:${port}->`));
 
     if (matching.length > 0) {
       console.log(`Docker container(s) found using port ${port}:`);
-      matching.forEach(c => console.log(c));
-      throw new Error(`Port ${port} is already mapped to a Docker container. Please stop the container or Please Free the port to get the GUI.`);
+      matching.forEach((c) => console.log(c));
+      throw new Error(
+        `Port ${port} is already mapped to a Docker container. Please stop the container or Please Free the port to get the GUI.`,
+      );
     }
   });
 }

--- a/source/server/config/keys.ts
+++ b/source/server/config/keys.ts
@@ -2,6 +2,7 @@ import path from "path";
 
 export enum ServerKeys {
   PORT = 27018,
+  LOCALHOST = "127.0.1",
 }
 
 export const staticPath = path.resolve(__dirname, "../public/AxioControl");

--- a/source/server/config/server.ts
+++ b/source/server/config/server.ts
@@ -4,8 +4,11 @@ import fastifyStatic from "@fastify/static";
 import path from "path";
 import fs from "fs";
 import { ServerKeys, staticPath } from "./keys";
+import checkPortAndDocker from "./PortFreeChecker";
 
 export default async function createAxioDBControlServer() {
+  await checkPortAndDocker(ServerKeys.PORT);
+
   const AxioDBControlServer = Fastify({
     logger: false, // Disable default logging
     trustProxy: true, // Trust the reverse proxy headers
@@ -54,7 +57,7 @@ export default async function createAxioDBControlServer() {
 
   try {
     await AxioDBControlServer.listen({
-      port: ServerKeys.PORT,
+      port: Number(ServerKeys.PORT),
       host: "0.0.0.0",
     });
     console.log(


### PR DESCRIPTION
This pull request introduces several changes aimed at improving the functionality and robustness of the AxioDB system. Key updates include implementing singleton behavior for the `AxioDB` class, adding port usage and Docker mapping checks to ensure proper server initialization, and updating configuration values. Below is a breakdown of the most important changes:

### Singleton Implementation for `AxioDB` Class
* Added a private static `_instance` property to enforce singleton behavior. The constructor now throws an error if an attempt is made to create multiple instances. (`source/Operation/Indexation.operation.ts`, [source/Operation/Indexation.operation.tsR35-R41](diffhunk://#diff-9f2790852c5bdf2065eac41dc6db310d4be1ebc4f900772e1ed7a648097ae594R35-R41))

### Port and Docker Mapping Checks
* Introduced `isPortInUse` and `checkDockerPortMapping` functions to verify port availability and detect Docker containers using the specified port. Errors are thrown if conflicts are found. (`source/server/config/PortFreeChecker.ts`, [source/server/config/PortFreeChecker.tsR1-R47](diffhunk://#diff-4ed9ebe50f1bcd6935305950ce79b72ea599eec858dde900c7b7489e4395affdR1-R47))
* Integrated the `checkPortAndDocker` function into the server initialization process to ensure the port is free before starting the AxioDB control server. (`source/server/config/server.ts`, [source/server/config/server.tsR7-R11](diffhunk://#diff-df028c2bee5fdea73aee907482eefd19e7f5695ebb41268bc54e497457a506d7R7-R11))

### Configuration Updates
* Added a new `LOCALHOST` constant to `ServerKeys` for improved configurability. (`source/server/config/keys.ts`, [source/server/config/keys.tsR5](diffhunk://#diff-d573aae8270d84c98f7246cee5ef2ee1a75d78f9f9764372c5bf48df2e888e70R5))
* Updated the `PORT` configuration in the server initialization to ensure it is treated as a numeric value. (`source/server/config/server.ts`, [source/server/config/server.tsL57-R60](diffhunk://#diff-df028c2bee5fdea73aee907482eefd19e7f5695ebb41268bc54e497457a506d7L57-R60))

### Version Increment
* Incremented the package version from `2.13.50` to `2.13.51` in `package.json`. (`package.json`, [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))