### PR TITLE
chore: update version to 2.18.55 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.18.54",
+  "version": "2.18.55",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request updates the version number of the `axiodb` package in `package.json` from `2.18.54` to `2.18.55`. This change likely reflects minor updates or bug fixes in the package.