### PR TITLE
fix: update version to 2.19.61 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.19.60",
+  "version": "2.19.61",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a minor version update to the `axiodb` package. The `version` field in `package.json` was incremented from `2.19.60` to `2.19.61` to reflect the latest changes.