### PR TITLE
fix: update version number to 2.19.65 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.19.64",
+  "version": "2.19.65",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a version bump for the `axiodb` package in the `package.json` file, updating the version from `2.19.64` to `2.19.65`.