### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -67,6 +67,8 @@ jobs:
   send_to_server:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/AnkanSaha/AxioDB/security/code-scanning/36](https://github.com/AnkanSaha/AxioDB/security/code-scanning/36)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the `send_to_server` job does not appear to require write access to the repository, we can set `contents: read` as the permission for this job. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the job level for `send_to_server` to limit its scope to this specific job. No additional imports, methods, or definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
