### PR TITLE
fix: update version to 2.21.67 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.21.66",
+  "version": "2.21.67",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file. The change increments the version number of the `axiodb` package from `2.21.66` to `2.21.67`.