### PR TITLE
fix: correct syntax for pages_build_output_dir in wrangler.toml

### DIFF
--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -6,7 +6,30 @@ on:
       - main
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check_changes.outputs.should_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for GUI or source changes
+        id: check_changes
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -E "^(GUI/|src/)" | head -1; then
+            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in GUI or source folders"
+          else
+            echo "should_build=false" >> $GITHUB_OUTPUT
+            echo "No changes detected in GUI or source folders"
+          fi
+
   test:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,7 +48,8 @@ jobs:
         run: npm run test
 
   publish_to_npm:
-    needs: test
+    needs: [check-changes, test]
+    if: needs.check-changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +70,8 @@ jobs:
         run: npm publish --access public
 
   publish_to_github:
-    needs: test
+    needs: [check-changes, test]
+    if: needs.check-changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,3 +95,11 @@ jobs:
           sed -i '2s/"axiodb"/"@${{ secrets.GIT_USER_NAME }}\/axiodb"/' package.json
       - name: Publish to GitHub Package Registry
         run: npm publish --registry=https://npm.pkg.github.com --scope=@${{ secrets.GIT_USER_NAME }} --access public
+
+  skip-deployment:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_build == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip deployment
+        run: echo "No GUI or source changes detected. Skipping build and deployment."

--- a/Document/wrangler.toml
+++ b/Document/wrangler.toml
@@ -6,8 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [env.preview]
 
-[[pages_build_output_dir]]
-directory = "AxioDB_Docs"
+pages_build_output_dir = "AxioDB_Docs"
 
 [build]
 command = "npm run build"


### PR DESCRIPTION
This pull request introduces enhancements to the CI/CD workflow in `.github/workflows/Push.yml` by adding a mechanism to skip unnecessary builds and deployments when no changes are detected in specific folders (`GUI/` or `src/`). Additionally, there is a minor configuration change in `Document/wrangler.toml` to simplify the build output directory specification. Below are the key changes:

### Workflow Enhancements:

* **New `check-changes` job**: Added a job to detect changes in the `GUI/` or `src/` directories. Outputs a flag (`should_build`) to determine whether subsequent jobs should run.
* **Conditional execution for `test`, `publish_to_npm`, and `publish_to_github` jobs**: Updated these jobs to depend on the `check-changes` job and only execute if `should_build` is `true`. [[1]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL28-R52) [[2]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL49-R74)
* **New `skip-deployment` job**: Added a job to log a message and skip deployment if no relevant changes are detected.

### Configuration Simplification:

* **`wrangler.toml` update**: Simplified the `pages_build_output_dir` configuration by replacing the array format with a single string assignment.