### PR TITLE
chore: update package versions and add Docker installation check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axiodb",
-  "version": "2.22.71",
+  "version": "2.25.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axiodb",
-      "version": "2.22.71",
+      "version": "2.25.72",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.25.72",
+  "version": "2.25.73",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/server/config/PortFreeChecker.ts
+++ b/source/server/config/PortFreeChecker.ts
@@ -102,7 +102,7 @@ export async function checkDockerPortMapping(port: number): Promise<void> {
  */
 export async function isDockerInstalled(): Promise<boolean> {
   return new Promise((resolve) => {
-    exec('docker --version', (error, stdout, stderr) => {
+    exec("docker --version", (error, stdout, stderr) => {
       if (error) {
         resolve(false); // Docker is not installed or not accessible
       } else {
@@ -122,7 +122,7 @@ export async function isDockerInstalled(): Promise<boolean> {
 export default async function checkPortAndDocker(port: number) {
   await isPortInUse(port);
   const status: boolean = await isDockerInstalled();
-  if(status) {
+  if (status) {
     await checkDockerPortMapping(port);
   }
 }

--- a/source/server/config/PortFreeChecker.ts
+++ b/source/server/config/PortFreeChecker.ts
@@ -86,6 +86,33 @@ export async function checkDockerPortMapping(port: number): Promise<void> {
 }
 
 /**
+ * Checks if Docker is installed on the system.
+ *
+ * @returns A Promise that resolves to true if Docker is installed, false otherwise
+ *
+ * @example
+ * ```typescript
+ * const dockerInstalled = await isDockerInstalled();
+ * if (dockerInstalled) {
+ *   console.log('Docker is available');
+ * } else {
+ *   console.log('Docker is not installed');
+ * }
+ * ```
+ */
+export async function isDockerInstalled(): Promise<boolean> {
+  return new Promise((resolve) => {
+    exec('docker --version', (error, stdout, stderr) => {
+      if (error) {
+        resolve(false); // Docker is not installed or not accessible
+      } else {
+        resolve(true); // Docker is installed
+      }
+    });
+  });
+}
+
+/**
  * Checks if a specified port is in use and if there's a Docker port mapping for that port.
  *
  * @param port - The port number to check
@@ -94,5 +121,8 @@ export async function checkDockerPortMapping(port: number): Promise<void> {
  */
 export default async function checkPortAndDocker(port: number) {
   await isPortInUse(port);
-  await checkDockerPortMapping(port);
+  const status: boolean = await isDockerInstalled();
+  if(status) {
+    await checkDockerPortMapping(port);
+  }
 }


### PR DESCRIPTION
This pull request introduces a new utility function to check for Docker installation and updates the port checking logic to use it. The main goal is to ensure that Docker port mapping is only checked if Docker is actually installed on the system.

**Enhancements to port checking logic:**

* Added a new function `isDockerInstalled` in `PortFreeChecker.ts` to detect if Docker is installed before attempting Docker-specific checks.
* Updated the `checkPortAndDocker` function in `PortFreeChecker.ts` to call `isDockerInstalled` and only check Docker port mappings if Docker is available.

**Other changes:**

* Bumped the package version in `package.json` from `2.25.72` to `2.25.73`.