### PR TITLE
feat: add caching and transaction token support for collections and d…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.27.77",
+  "version": "2.28.77",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/server/controller/Collections/Collection.controller.ts
+++ b/source/server/controller/Collections/Collection.controller.ts
@@ -5,6 +5,7 @@ import buildResponse, {
 } from "../../helper/responseBuilder.helper";
 import { FastifyRequest } from "fastify";
 import countFilesRecursive from "../../helper/filesCounterInFolder.helper";
+import GlobalStorageConfig from "../../config/GlobalStorage.config";
 
 /**
  * Controller class for managing collections in AxioDB.
@@ -92,9 +93,22 @@ export default class CollectionController {
    */
   public async getCollections(
     request: FastifyRequest,
+    transactionToken: string
   ): Promise<ResponseBuilder> {
     // extract databaseName from url query
     const { databaseName } = request.query as { databaseName: string };
+
+          // check cache
+          if (
+            transactionToken &&
+            GlobalStorageConfig.get(`${databaseName}${transactionToken}`) != undefined
+          ) {
+            return buildResponse(
+              StatusCodes.OK,
+              "Dashboard stats fetched successfully",
+              GlobalStorageConfig.get(`${databaseName}${transactionToken}`),
+            );
+          }
 
     if (!databaseName) {
       return buildResponse(
@@ -123,6 +137,14 @@ export default class CollectionController {
           mainData.CollectionSizeMap.push({ folderPath, fileCount });
         }),
       ]);
+
+      // Cache the response
+      if (
+        transactionToken &&
+        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) == undefined
+      ) {
+        GlobalStorageConfig.set(`dashboard_stats_${transactionToken}`, mainData);
+      }
 
       return buildResponse(
         StatusCodes.OK,

--- a/source/server/controller/Collections/Collection.controller.ts
+++ b/source/server/controller/Collections/Collection.controller.ts
@@ -93,22 +93,22 @@ export default class CollectionController {
    */
   public async getCollections(
     request: FastifyRequest,
-    transactionToken: string
+    transactionToken: string,
   ): Promise<ResponseBuilder> {
     // extract databaseName from url query
     const { databaseName } = request.query as { databaseName: string };
 
-          // check cache
-          if (
-            transactionToken &&
-            GlobalStorageConfig.get(`${databaseName}${transactionToken}`) != undefined
-          ) {
-            return buildResponse(
-              StatusCodes.OK,
-              "Dashboard stats fetched successfully",
-              GlobalStorageConfig.get(`${databaseName}${transactionToken}`),
-            );
-          }
+    // check cache
+    if (
+      transactionToken &&
+      GlobalStorageConfig.get(`${databaseName}${transactionToken}`) != undefined
+    ) {
+      return buildResponse(
+        StatusCodes.OK,
+        "Dashboard stats fetched successfully",
+        GlobalStorageConfig.get(`${databaseName}${transactionToken}`),
+      );
+    }
 
     if (!databaseName) {
       return buildResponse(
@@ -141,9 +141,13 @@ export default class CollectionController {
       // Cache the response
       if (
         transactionToken &&
-        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) == undefined
+        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) ==
+          undefined
       ) {
-        GlobalStorageConfig.set(`dashboard_stats_${transactionToken}`, mainData);
+        GlobalStorageConfig.set(
+          `dashboard_stats_${transactionToken}`,
+          mainData,
+        );
       }
 
       return buildResponse(

--- a/source/server/controller/Database/Databse.controller.ts
+++ b/source/server/controller/Database/Databse.controller.ts
@@ -4,6 +4,7 @@ import buildResponse, {
   ResponseBuilder,
 } from "../../helper/responseBuilder.helper";
 import { FastifyRequest } from "fastify";
+import GlobalStorageConfig from "../../config/GlobalStorage.config";
 
 /**
  * Controller class for managing databases in AxioDB.
@@ -29,8 +30,27 @@ export default class DatabaseController {
    * const response = await databaseController.getDatabases();
    * // Returns a ResponseBuilder with status 200 and database list
    */
-  public async getDatabases(): Promise<ResponseBuilder> {
+  public async getDatabases(transactionToken: string): Promise<ResponseBuilder> {
+      // check cache
+      if (
+        transactionToken &&
+        GlobalStorageConfig.get(`database_${transactionToken}`) != undefined
+      ) {
+        return buildResponse(
+          StatusCodes.OK,
+          "List of Databases",
+          GlobalStorageConfig.get(`database_${transactionToken}`),
+        );
+      }
+
     const databases = await this.AxioDBInstance.getInstanceInfo();
+          // Cache the response
+          if (
+            transactionToken &&
+            GlobalStorageConfig.get(`database_${transactionToken}`) == undefined
+          ) {
+            GlobalStorageConfig.set(`database_${transactionToken}`, databases?.data);
+          }
     return buildResponse(StatusCodes.OK, "List of Databases", databases?.data);
   }
 

--- a/source/server/controller/Database/Databse.controller.ts
+++ b/source/server/controller/Database/Databse.controller.ts
@@ -30,27 +30,29 @@ export default class DatabaseController {
    * const response = await databaseController.getDatabases();
    * // Returns a ResponseBuilder with status 200 and database list
    */
-  public async getDatabases(transactionToken: string): Promise<ResponseBuilder> {
-      // check cache
-      if (
-        transactionToken &&
-        GlobalStorageConfig.get(`database_${transactionToken}`) != undefined
-      ) {
-        return buildResponse(
-          StatusCodes.OK,
-          "List of Databases",
-          GlobalStorageConfig.get(`database_${transactionToken}`),
-        );
-      }
+  public async getDatabases(
+    transactionToken: string,
+  ): Promise<ResponseBuilder> {
+    // check cache
+    if (
+      transactionToken &&
+      GlobalStorageConfig.get(`database_${transactionToken}`) != undefined
+    ) {
+      return buildResponse(
+        StatusCodes.OK,
+        "List of Databases",
+        GlobalStorageConfig.get(`database_${transactionToken}`),
+      );
+    }
 
     const databases = await this.AxioDBInstance.getInstanceInfo();
-          // Cache the response
-          if (
-            transactionToken &&
-            GlobalStorageConfig.get(`database_${transactionToken}`) == undefined
-          ) {
-            GlobalStorageConfig.set(`database_${transactionToken}`, databases?.data);
-          }
+    // Cache the response
+    if (
+      transactionToken &&
+      GlobalStorageConfig.get(`database_${transactionToken}`) == undefined
+    ) {
+      GlobalStorageConfig.set(`database_${transactionToken}`, databases?.data);
+    }
     return buildResponse(StatusCodes.OK, "List of Databases", databases?.data);
   }
 

--- a/source/server/controller/Stats.controller.ts
+++ b/source/server/controller/Stats.controller.ts
@@ -42,12 +42,12 @@ export default class StatsController {
       // check cache
       if (
         transactionToken &&
-        GlobalStorageConfig.get(`dashboard_stats`) != undefined
+        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) != undefined
       ) {
         return buildResponse(
           StatusCodes.OK,
           "Dashboard stats fetched successfully",
-          GlobalStorageConfig.get(`dashboard_stats`),
+          GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`),
         );
       }
 
@@ -138,9 +138,9 @@ export default class StatsController {
       // Cache the response
       if (
         transactionToken &&
-        GlobalStorageConfig.get(`dashboard_stats`) == undefined
+        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) == undefined
       ) {
-        GlobalStorageConfig.set(`dashboard_stats`, response);
+        GlobalStorageConfig.set(`dashboard_stats_${transactionToken}`, response);
       }
       return buildResponse(
         StatusCodes.OK,

--- a/source/server/controller/Stats.controller.ts
+++ b/source/server/controller/Stats.controller.ts
@@ -42,7 +42,8 @@ export default class StatsController {
       // check cache
       if (
         transactionToken &&
-        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) != undefined
+        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) !=
+          undefined
       ) {
         return buildResponse(
           StatusCodes.OK,
@@ -138,9 +139,13 @@ export default class StatsController {
       // Cache the response
       if (
         transactionToken &&
-        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) == undefined
+        GlobalStorageConfig.get(`dashboard_stats_${transactionToken}`) ==
+          undefined
       ) {
-        GlobalStorageConfig.set(`dashboard_stats_${transactionToken}`, response);
+        GlobalStorageConfig.set(
+          `dashboard_stats_${transactionToken}`,
+          response,
+        );
       }
       return buildResponse(
         StatusCodes.OK,

--- a/source/server/router/Routers/Collection.routes.ts
+++ b/source/server/router/Routers/Collection.routes.ts
@@ -19,11 +19,13 @@ export default async function collectionRouter(
   const { AxioDBInstance } = options;
 
   // Get All Collection
-  fastify.get("/all/", async (request, reply) =>{
+  fastify.get("/all/", async (request, reply) => {
     const transactionToken = (request.query as any)?.transactiontoken;
-    return new CollectionController(AxioDBInstance).getCollections(request, transactionToken)
-  }
-  );
+    return new CollectionController(AxioDBInstance).getCollections(
+      request,
+      transactionToken,
+    );
+  });
 
   // Create Collection
   fastify.post("/create-collection", async (request, reply) =>

--- a/source/server/router/Routers/Collection.routes.ts
+++ b/source/server/router/Routers/Collection.routes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import buildResponse from "../../helper/responseBuilder.helper";
@@ -18,8 +19,10 @@ export default async function collectionRouter(
   const { AxioDBInstance } = options;
 
   // Get All Collection
-  fastify.get("/all/", async (request, reply) =>
-    new CollectionController(AxioDBInstance).getCollections(request),
+  fastify.get("/all/", async (request, reply) =>{
+    const transactionToken = (request.query as any)?.transactiontoken;
+    return new CollectionController(AxioDBInstance).getCollections(request, transactionToken)
+  }
   );
 
   // Create Collection

--- a/source/server/router/Routers/DB.routes.ts
+++ b/source/server/router/Routers/DB.routes.ts
@@ -21,7 +21,9 @@ export default async function dbRouter(
   // Get all databases
   fastify.get("/databases", async (request) => {
     const transactionToken = (request.query as any)?.transactiontoken;
-    return new DatabaseController(AxioDBInstance).getDatabases(transactionToken);
+    return new DatabaseController(AxioDBInstance).getDatabases(
+      transactionToken,
+    );
   });
 
   // Create a new database

--- a/source/server/router/Routers/DB.routes.ts
+++ b/source/server/router/Routers/DB.routes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import buildResponse from "../../helper/responseBuilder.helper";
@@ -18,9 +19,10 @@ export default async function dbRouter(
   const { AxioDBInstance } = options; // Access the AxioDB instance passed from the main router
 
   // Get all databases
-  fastify.get("/databases", async () =>
-    new DatabaseController(AxioDBInstance).getDatabases(),
-  );
+  fastify.get("/databases", async (request) => {
+    const transactionToken = (request.query as any)?.transactiontoken;
+    return new DatabaseController(AxioDBInstance).getDatabases(transactionToken);
+  });
 
   // Create a new database
   fastify.post("/create-database", async (request) =>


### PR DESCRIPTION
This pull request introduces caching for database and collection stats endpoints, improving performance by reducing redundant data fetching. The implementation uses a transaction token to store and retrieve cached responses, ensuring that repeated requests with the same token return quickly. Additionally, the relevant routes have been updated to accept and pass the transaction token. The package version is also incremented.

**Caching implementation and usage:**

* Added caching logic to `CollectionController.getCollections` and `DatabaseController.getDatabases`, using `GlobalStorageConfig` and a `transactionToken` to store and retrieve cached responses. [[1]](diffhunk://#diff-546031fe18320c607ce233f40d17b81f2b9ed9c63183b95cf5e06b853bf4c725R96-R112) [[2]](diffhunk://#diff-546031fe18320c607ce233f40d17b81f2b9ed9c63183b95cf5e06b853bf4c725R141-R148) [[3]](diffhunk://#diff-6c14f1112de4becb1a302984143c9c9afc592935f91f0eb67c426d79433ee4c1L32-R53)
* Updated `StatsController` to use token-specific cache keys for dashboard stats, ensuring cache isolation per transaction. [[1]](diffhunk://#diff-d43408bc6f183748371092dabe7ff7a777df00cdbd755e93c3a5fe13121b8eebL45-R50) [[2]](diffhunk://#diff-d43408bc6f183748371092dabe7ff7a777df00cdbd755e93c3a5fe13121b8eebL141-R143)

**Route and API changes:**

* Modified `Collection.routes.ts` and `DB.routes.ts` to extract the `transactiontoken` from query parameters and pass it to the respective controller methods. [[1]](diffhunk://#diff-a8367b10296dcbf26dd6ca346cc3272e9285650192ce93acfcd18f3905ec63c3L21-R25) [[2]](diffhunk://#diff-e95627163702194d5ab6d5e335df6768826c70d7c14b437c53c13130d5af7065L21-R25)

**Miscellaneous:**

* Incremented the package version in `package.json` to `2.28.77`.
* Added TypeScript linting disables for explicit `any` usage in router files. [[1]](diffhunk://#diff-a8367b10296dcbf26dd6ca346cc3272e9285650192ce93acfcd18f3905ec63c3R1) [[2]](diffhunk://#diff-e95627163702194d5ab6d5e335df6768826c70d7c14b437c53c13130d5af7065R1)…atabases