### PR TITLE
fix: update version number to 2.31.96 in package.json and remove unus…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.31.95",
+  "version": "2.31.96",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/server/config/PortFreeChecker.ts
+++ b/source/server/config/PortFreeChecker.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import net from "net";
-import { exec } from "child_process";
 import { ServerKeys } from "./keys";
 
 /**


### PR DESCRIPTION
This pull request includes minor updates to the project. The version number in `package.json` has been incremented, and an unused import has been removed from the port checker configuration file.

* Version bump:
  - Updated the project version in `package.json` from `2.31.95` to `2.31.96`.

* Code cleanup:
  - Removed the unused `exec` import from `source/server/config/PortFreeChecker.ts`.…ed import in PortFreeChecker.ts