### PR TITLE
chore: bump version to 9.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
## Summary
This PR updates the version of `axiodb` from `9.6.2` to `9.6.3` in `package.json`.

## Changes
- Updated `version` field in `package.json`.

## Verification
- Manual check of `package.json` file integrity.
- No functional changes introduced, hence no regression expected.