### PR TITLE
chore: bump version to 9.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "9.6.4",
+  "version": "9.6.5",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
## Summary
This PR performs a version bump from 9.6.3 to 9.6.5 in `package.json`. 

## Changes
- Updated `version` field in `package.json` from `9.6.3` to `9.6.5`.
- Note: Version `9.6.4` was apparently skipped for mysterious reasons known only to the author.

## Verification
- [x] Verified that 9.6.5 is indeed a larger number than 9.6.3.
- [x] Confirmed that no actual code was harmed or improved during this process.